### PR TITLE
Remove hmatrix version constraint below 0.15

### DIFF
--- a/spatial-math.cabal
+++ b/spatial-math.cabal
@@ -17,7 +17,7 @@ library
                        Xyz
   -- other-modules:       
   build-depends:       base >= 4 && < 5,
-                       hmatrix >= 0.14 && < 0.15,
+                       hmatrix >= 0.14,
                        random
 
 source-repository head


### PR DESCRIPTION
Builds on debian sid i686, and I see no errors at runtime.  No test suite, so your guess is as good as mine.
