### PR TITLE
import Applicative `pure`

### DIFF
--- a/src/SpatialMathT.hs
+++ b/src/SpatialMathT.hs
@@ -31,7 +31,7 @@ module SpatialMathT
        , (:.)(..), unO
        ) where
 
-import Control.Applicative ( Applicative )
+import Control.Applicative ( Applicative, pure)
 import Control.Compose ( (:.)(..), unO )
 import Data.Foldable ( Foldable )
 import Data.Binary ( Binary(..) )


### PR DESCRIPTION
I had to fix `cabal build`.  Interestingly, `stack build` worked fine already.

```
~/haskell/spatial-math $ cabal build 
Building spatial-math-0.4.0.0...
Preprocessing library spatial-math-0.4.0.0...
[3 of 3] Compiling SpatialMathT     ( src/SpatialMathT.hs, dist/build/SpatialMathT.o )

src/SpatialMathT.hs:104:33: Not in scope: `pure'
```

Cabal builds now:

```
~/haskell/spatial-math $ cabal build 
Building spatial-math-0.4.0.0...
Preprocessing library spatial-math-0.4.0.0...
[3 of 3] Compiling SpatialMathT     ( src/SpatialMathT.hs, dist/build/SpatialMathT.o )
In-place registering spatial-math-0.4.0.0...
```

I initially encountered this when trying to install `casadi-bindings`:

```

~/haskell/dynobud $ cabal update && cabal install casadi-bindings 
Downloading the latest package list from hackage.haskell.org
Skipping download: Local and remote files match.
Resolving dependencies...
Downloading StateVar-1.1.0.4...
Downloading base-orphans-0.6...
Configuring StateVar-1.1.0.4...
Downloading bytestring-builder-0.10.8.1.0...
Downloading fail-4.9.0.0...
Configuring base-orphans-0.6...
Downloading generic-deriving-1.11.2...
...
Build log ( /home/peterbecich/.cabal/logs/spatial-math-0.4.0.0.log ):
Configuring spatial-math-0.4.0.0...
Building spatial-math-0.4.0.0...
Preprocessing library spatial-math-0.4.0.0...
[1 of 3] Compiling Types            ( src/Types.hs, dist/build/Types.o )

src/Types.hs:56:10: Warning:
    No explicit method or default declaration for `Data.Binary.put'
    In the instance declaration for `Binary (Euler a)'

src/Types.hs:56:10: Warning:
    No explicit method or default declaration for `Data.Binary.get'
    In the instance declaration for `Binary (Euler a)'
[2 of 3] Compiling SpatialMath      ( src/SpatialMath.hs, dist/build/SpatialMath.o )
[3 of 3] Compiling SpatialMathT     ( src/SpatialMathT.hs, dist/build/SpatialMathT.o )

src/SpatialMathT.hs:104:33: Not in scope: `pure'
cabal: Error: some packages failed to install:
casadi-bindings-3.1.0.3 depends on spatial-math-0.4.0.0 which failed to
install.
spatial-math-0.4.0.0 failed during the building phase. The exception was:
ExitFailure 1
```