### PR TITLE
Fix doctest include path

### DIFF
--- a/tests/doctests.hs
+++ b/tests/doctests.hs
@@ -5,4 +5,4 @@ module Main where
 import Test.DocTest
 
 main :: IO ()
-main = doctest ["src/Types.hs", "src/SpatialMath.hs"]
+main = doctest ["-isrc", "src/Types.hs", "src/SpatialMath.hs"]


### PR DESCRIPTION
Doctest was not providing the correct `-i` path. I ignore why it was working previously.

This fix makes `spatial-math` build on nix without any override.

If this PR is accepted, please can you upload a new package to hackage, this way, nix will quickly automatically pick that fix.